### PR TITLE
Updated to postgres-types = "0.2"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "postgres-inet"
-version = "0.17.0"
+version = "0.19.0"
 authors = ["Nuew <code@nuew.net>"]
 license = "Apache-2.0"
 description = "CIDR/INET support for rust-postgres"
@@ -17,7 +17,7 @@ maintenance = { status = "passively-maintained" }
 [dependencies]
 bytes = "0.5"
 ipnetwork = { version = ">=0.7, <0.16", optional = true }
-postgres-types = "0.1"
+postgres-types = "0.2"
 
 [dev-dependencies]
-postgres = "0.17"
+postgres = "0.19.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,13 +40,12 @@ extern crate ipnetwork;
 #[cfg(test)]
 extern crate postgres;
 
-extern crate bytes;
 #[macro_use]
 extern crate postgres_types;
 
 mod tests;
 
-use bytes::BytesMut;
+use postgres_types::private::BytesMut;
 use postgres_types::{FromSql, IsNull, ToSql, Type};
 use std::error::Error;
 use std::fmt;
@@ -479,15 +478,12 @@ impl fmt::Display for MaskedIpAddrParseError {
         match *self {
             MaskedIpAddrParseError::Address(ref e) => e.fmt(f),
             MaskedIpAddrParseError::Netmask(ref e) => e.fmt(f),
-            MaskedIpAddrParseError::Format => f.write_str(self.description()),
+            MaskedIpAddrParseError::Format => f.write_str("invalid CIDR syntax"),
         }
     }
 }
 
 impl Error for MaskedIpAddrParseError {
-    fn description(&self) -> &str {
-        "invalid CIDR syntax"
-    }
 
     fn cause(&self) -> Option<&dyn Error> {
         match *self {


### PR DESCRIPTION
Update to  postgres-types = "0.2" to make it compatible with newer versions of deadpool-postgres.